### PR TITLE
尝试修复 新事件 动作消息 导致的机器人框架崩溃

### DIFF
--- a/core/src/main/java/cn/enaium/kook/spring/boot/starter/connect/WebSocketClient.java
+++ b/core/src/main/java/cn/enaium/kook/spring/boot/starter/connect/WebSocketClient.java
@@ -104,6 +104,10 @@ public class WebSocketClient {
                         TextMessageExtra extra = JsonUtil.mapper().readValue(json, new TypeReference<Sign<EventData<TextMessageExtra>>>() {
                         }).d.extra;
                         String type = String.valueOf(extra.type);
+                        //TODO 此功能目前治标不治本, 但是可以解决问题
+                        if ("0".equals(type)) {
+                            type = String.valueOf(eventDataSign.d.type);
+                        }
                         Class<?> event = eventManager.listener.get(type);
                         eventManager.publish(JsonUtil.readData(JsonUtil.writeValueAsString(sign.d), event), event);
                     }

--- a/core/src/main/java/cn/enaium/kook/spring/boot/starter/model/sign/data/extra/TextMessageExtra.java
+++ b/core/src/main/java/cn/enaium/kook/spring/boot/starter/model/sign/data/extra/TextMessageExtra.java
@@ -24,7 +24,7 @@ import cn.enaium.kook.spring.boot.starter.model.object.UserObject;
  */
 public class TextMessageExtra {
     /**
-     * 1:文字消息, 2:图片消息，3:视频消息，4:文件消息， 8:音频消息，9:KMarkdown，10:card 消息，255:系统消息, 其它的暂未开放
+     * 1:文字消息, 2:图片消息，3:视频消息，4:文件消息， 8:音频消息，9:KMarkdown，10:card 消息，12:动作消息 255:系统消息, 其它的暂未开放
      */
     public int type;
 

--- a/core/src/main/java/cn/enaium/kook/spring/boot/starter/model/sign/data/extra/event/message/ImageAnimationMessage.java
+++ b/core/src/main/java/cn/enaium/kook/spring/boot/starter/model/sign/data/extra/event/message/ImageAnimationMessage.java
@@ -1,0 +1,22 @@
+package cn.enaium.kook.spring.boot.starter.model.sign.data.extra.event.message;
+
+import cn.enaium.kook.spring.boot.starter.annotation.event.Listener;
+import cn.enaium.kook.spring.boot.starter.model.sign.data.extra.TextMessageExtra;
+
+import java.util.Map;
+
+/**
+ * 动作消息,可能并非正式命名
+ * 详细报文可见 <a href="https://github.com/kaiheila/api-docs/issues/150">kook/api-docs</a>
+ * @author CNLuminous
+ * @since 0.1.4
+ */
+@Listener
+public class ImageAnimationMessage extends TextMessageExtra {
+    public static final String TYPE = "12";
+
+    /**
+     * 动作内容
+     */
+    public Map<Object,Object> item_part;
+}


### PR DESCRIPTION
信令可见 [[kook/api-docs/issues/150](https://github.com/kaiheila/api-docs/issues/150)](https://github.com/kaiheila/api-docs/issues/150#issuecomment-1236230021)
具体问题出现在 https://github.com/Enaium/kook-spring-boot-starter/blob/74a8500987197dec9422e766c61e5cde65f2df73/core/src/main/java/cn/enaium/kook/spring/boot/starter/connect/WebSocketClient.java#L106
问题表现为 之前所有的消息事件中均在extra存在type字段，而在新的 动作消息 中，extra去除此字段并且存放于extra{item_part[resources{type}]}中，导致获取到的type为0从而导致机器人出现异常无法处理数据，出现崩溃现象在新的 动作消息 中.目前代码中获取到的type均于extra中，除非kook官方修改api接口从新将此放于extra 字段中，本次尝试修复逻辑为新增类ImageAnimationMessage定义type12，并且在WebSocketClient中判断type是否为0，若为0则使用eventDataSign.d.type